### PR TITLE
Add `jupyter.kernelPortsBase` option to replace hard-coded const

### DIFF
--- a/package.json
+++ b/package.json
@@ -1582,6 +1582,14 @@
                     "description": "Amount of time (in ms) to wait for the Jupyter Notebook server to start.",
                     "scope": "resource"
                 },
+                "jupyter.kernelPortsBase": {
+                    "type": "number",
+                    "default": 29000,
+                    "minimum": 1024,
+                    "maximum": 65000,
+                    "description": "Lowest port number used for communication with Jupyter kernel.",
+                    "scope": "resource"
+                },
                 "jupyter.jupyterLaunchRetries": {
                     "type": "number",
                     "default": 3,


### PR DESCRIPTION
We add `jupyter.kernelPortsBase` config option to control the start port used for kernel communication channels.

Upstream, the start port is hard-coded to 9000.

In #3 we increased the base port number (still hard-coded), and here we generalize that by exposing it through a config option.